### PR TITLE
napval perfomance

### DIFF
--- a/app/napval/napval_nss.cfg
+++ b/app/napval/napval_nss.cfg
@@ -5,7 +5,10 @@ id: "nap-val"
 # Store type
 # Can be st, store, store_type or StoreType
 # Possible values are file or memory (case insensitive)
-store: "memory"
+store: "file"
+
+# stream file store directory
+dir: "./nss"
 
 # Debug flag.
 # Can be sd or stand_debug

--- a/napval/idservice3.go
+++ b/napval/idservice3.go
@@ -3,12 +3,13 @@ package napval
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/nats-io/go-nats"
 	"github.com/nsip/nias2/lib"
 	"github.com/nsip/nias2/xml"
 	"github.com/orcaman/concurrent-map"
 	"gopkg.in/fatih/set.v0"
-	"log"
 )
 
 // id service requires too much overhead using ledis.
@@ -205,7 +206,7 @@ func (ids *IDService3) HandleMessage(req *lib.NiasMessage) ([]lib.NiasMessage, e
 		// r.Target = VALIDATION_PREFIX
 		r.Body = ve
 		responses = append(responses, r)
-		log.Printf("simplekey: %s\nsimplekey2: %s\ncompllexkey: %s", simpleKey1, simpleKey2, complexKey)
+		// log.Printf("simplekey: %s\nsimplekey2: %s\ncompllexkey: %s", simpleKey1, simpleKey2, complexKey)
 
 	}
 


### PR DESCRIPTION
nss config set ot memory, should be file to prevent slow consumer failures.
idservice3 was producing verbose dubug outpiut to console.