### PR TITLE
Rebuild for distribution

### DIFF
--- a/app/naprrql/reporting_templates/school/schoolItemResults.xgql
+++ b/app/naprrql/reporting_templates/school/schoolItemResults.xgql
@@ -1,4 +1,4 @@
-query NAPDomainScores($acaraIDs: [String]) {
+query NAPItemResults($acaraIDs: [String]) {
   item_results_report_by_school(acaraIDs: $acaraIDs) {
     Test {
       TestContent {

--- a/app/naprrql/reporting_templates/system/systemItemResults.xgql
+++ b/app/naprrql/reporting_templates/system/systemItemResults.xgql
@@ -1,4 +1,4 @@
-query NAPDomainScores($acaraIDs: [String]) {
+query NAPItemResults($acaraIDs: [String]) {
   item_results_report_by_school(acaraIDs: $acaraIDs) {
     Test {
       TestContent {


### PR DESCRIPTION
restored missing folders to build
renamed new queries so they show uo without the name of an existing query for debugging
removed item reports from default report set by renaming until issues with query are resolved.